### PR TITLE
Update README to use clone via https

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install [Yarn](https://yarnpkg.com/en/docs/install).
 ### Get the source code and install dependencies.
 
 ```
-$ git clone git@github.com:contentful/covid-19-site-template.git
+$ git clone https://github.com/contentful/covid-19-site-template.git
 $ yarn install
 ```
 


### PR DESCRIPTION
This avoids permission errors;

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```