### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ contentful login
 ```
 
 ```sh
-contentful space import --space-id=<space-id> --content-file ./contentful/export.json
-```
-
-```sh
 rm static/_redirects
 ```
 


### PR DESCRIPTION
no need to separately run the `contentful space import` command as `yarn setup` also does the space import as part of the setup process.