### PR TITLE
Added support to create this site with Stackbit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
 CF_COVID_ACCESS_TOKEN=<contentful-delivery-key>
 CF_COVID_SPACE_ID=<contentful-space-id>
-COVID_COUNTRY=<country-iso2>

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ public
 
 # contentful cli
 contentful-import*
+country-codes.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ You must have a Contentful account to use this project. If you don’t have an a
 
 The following instructions are helpful is you have Yarn installed. If not, please install [Yarn](https://yarnpkg.com/en/docs/install).
 
+## Create with Stackbit
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/smnh/covid-19-site-template&ssg=gatsby&cms=contentful&cmsExclusive)
+
 ### Get the source code and install dependencies.
 
 ```

--- a/contentful/export.json
+++ b/contentful/export.json
@@ -728,6 +728,31 @@
           "omitted": false
         },
         {
+          "id": "covidCountries",
+          "name": "Covid Countries",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "size": {
+                  "min": 2,
+                  "max": 2
+                }
+              },
+              {
+                "in": ["AF","AX","AL","DZ","AS","AD","AO","AI","AQ","AG","AR","AM","AW","AU","AT","AZ","BS","BH","BD","BB","BY","BE","BZ","BJ","BM","BT","BO","BQ","BA","BW","BV","BR","IO","BN","BG","BF","BI","KH","CM","CA","CV","KY","CF","TD","CL","CN","CX","CC","CO","KM","CG","CD","CK","CR","CI","HR","CU","CW","CY","CZ","DK","DJ","DM","DO","EC","EG","SV","GQ","ER","EE","ET","FK","FO","FJ","FI","FR","GF","PF","TF","GA","GM","GE","DE","GH","GI","GR","GL","GD","GP","GU","GT","GG","GN","GW","GY","HT","HM","VA","HN","HK","HU","IS","IN","ID","IR","IQ","IE","IM","IL","IT","JM","JP","JE","JO","KZ","KE","KI","KP","KR","KW","KG","LA","LV","LB","LS","LR","LY","LI","LT","LU","MO","MK","MG","MW","MY","MV","ML","MT","MH","MQ","MR","MU","YT","MX","FM","MD","MC","MN","ME","MS","MA","MZ","MM","NA","NR","NP","NL","NC","NZ","NI","NE","NG","NU","NF","MP","NO","OM","PK","PW","PS","PA","PG","PY","PE","PH","PN","PL","PT","PR","QA","RE","RO","RU","RW","BL","SH","KN","LC","MF","PM","VC","WS","SM","ST","SA","SN","RS","SC","SL","SG","SX","SK","SI","SB","SO","ZA","GS","SS","ES","LK","SD","SR","SJ","SZ","SE","CH","SY","TW","TJ","TZ","TH","TL","TG","TK","TO","TT","TN","TR","TM","TC","TV","UG","UA","AE","GB","US","UM","UY","UZ","VU","VE","VN","VG","VI","WF","EH","YE","ZM","ZW"],
+                "message": "The country code must match one of available Alpha-2 codes - https://www.nationsonline.org/oneworld/country_code_list.htm"
+              }
+            ]
+          }
+        },
+        {
           "id": "twitterUsername",
           "name": "Twitter Username",
           "type": "Symbol",
@@ -1282,6 +1307,14 @@
         {
           "fieldId": "siteLocale",
           "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "covidCountries",
+          "settings": {
+            "helpText": "Enter ISO Alpha-2 country code, list of available codes - https://www.nationsonline.org/oneworld/country_code_list.htm"
+          },
+          "widgetId": "tagEditor",
           "widgetNamespace": "builtin"
         },
         {
@@ -3412,6 +3445,11 @@
         },
         "siteLocale": {
           "en-US": "en-US"
+        },
+        "covidCountries": {
+          "en-US": [
+            "US", "GB"
+          ]
         },
         "twitterUsername": {
           "en-US": "contentful"

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,7 +17,7 @@ module.exports = {
     {
       resolve: 'gatsby-source-mathdroid-covid19',
       options: {
-        countries: [{ iso2: process.env.COVID_COUNTRY }],
+        countries: require('./country-codes.json').map(countryCode => ({ iso2: countryCode })),
       },
     },
     {

--- a/get-countries.js
+++ b/get-countries.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+const https = require('https');
+const fs = require('fs');
+
+const options = {
+  'method': 'GET',
+  'hostname': 'cdn.contentful.com',
+  'path': `/spaces/${process.env.CF_COVID_SPACE_ID}/environments/master/entries?content_type=siteMetadata&select=fields.covidCountries`,
+  'headers': { 'Authorization': `Bearer ${process.env.CF_COVID_ACCESS_TOKEN}` }
+};
+
+const req = https.request(options, (res) => {
+  let data = '';
+
+  res.on('data', (chunk) => {
+    data += chunk;
+  });
+
+  res.on('end', () => {
+    try {
+      data = JSON.parse(data);
+      const countries = data.items[0].fields.covidCountries;
+      fs.writeFileSync('country-codes.json', JSON.stringify(countries));
+      process.exit(0);
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    }
+  });
+
+});
+
+req.on('error', error => {
+  console.error(error);
+  process.exit(1);
+})
+
+req.end();

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "setup": "node bin/setup",
-    "build": "gatsby build",
-    "develop": "gatsby develop"
+    "build": "node get-countries.js && gatsby build",
+    "develop": "node get-countries.js && gatsby develop"
   }
 }

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,8 @@
+ssgName: gatsby
+buildCommand: rm -f static/_redirects ; npm run build
+publishDir: public
+import:
+  type: contentful
+  spaceIdEnvVar: CF_COVID_SPACE_ID
+  accessTokenEnvVar: CF_COVID_ACCESS_TOKEN
+  contentFile: ./contentful/export.json


### PR DESCRIPTION
This PR allows anyone to deploy this site in a matter of minutes using Stackbit.

- added “Create with Stackbit” button to README.md that pre-configures this site in Stackbit
- added stackbit.yaml with configuration allowing Stackbit to provision Contentful with exported data and deploy the site to Netlify.

[![Create Covid-19 site with Stackbit in 5 minutes](http://img.youtube.com/vi/24IrIP4XHs4/0.jpg)](http://www.youtube.com/watch?v=24IrIP4XHs4 "Create Covid-19 site with Stackbit in 5 minutes")